### PR TITLE
sshd_config: include sshd_config.d if version > 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ These variables are defined in [defaults/main.yml](./defaults/main.yml):
 
     openssh_configuration_match_blocks: {}
 
+`Include: /etc/ssh/sshd_config.d/*.conf` will always be added to the configuration if the OpenSSH server supports it (> 8.2).
 
 Dependencies
 ------------
@@ -37,7 +38,6 @@ Example Playbook
         - role: ansible-role-openssh
           vars:
             openssh_configuration:
-              #Include: /etc/ssh/sshd_config.d/*.conf
               ## Configuration
               Port: 22
               ListenAddress:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
+# The Include statement in sshd_config is available since version 8.2: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=631189
 ---
 
 - name: establish packages
@@ -24,6 +25,16 @@
     path: "{{ openssh_run_directory }}"
     state: directory
     mode: "u=rwx,go=rx"
+
+- name: Get SSH version
+  command:
+    argv:
+    - bash
+    - -c
+    - ssh -V 2>&1 | cut -d' ' -f 1 | grep -Eo '[0-9.]+' | head -n 1
+  register: ssh_version
+# also run this task in check mode:
+  check_mode: no
 
 - name: configure openssh
   when: openssh_configuration != {}

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -1,5 +1,9 @@
 {{ ansible_managed | comment }}
 
+{% if ssh_version.stdout is version('8.2', '>') %}
+Include /etc/ssh/sshd_config.d/*.conf
+{% endif %}
+
 {% macro render_value(k,v, indent='') -%}
 {%  if v.__class__.__name__ == 'list' %}
 {%     for vv in v %}


### PR DESCRIPTION
The statement
Include /etc/ssh/sshd_config.d/*.conf
is default and only available in OpenSSH versions higher thatn 8.2.
If this is the case, always insert the statement into the configuration.

As discussed in https://github.com/Provizanta/ansible-role-openssh/commit/91ea8a0ec3bd885c75f164560505e3d92b53335d#r65012398-permalink
