### PR TITLE
Add capability to save configuration in an ssh dotdir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           path: "${{ github.repository }}"
 
       - name: run molecule
-        uses: robertdebock/molecule-action@2.6.1
+        uses: robertdebock/molecule-action@2.6.1      # 4.0.6
         env:
           MOLECULE_DISTRO: ${{ matrix.distro }}
 
@@ -38,6 +38,6 @@ jobs:
     steps:
       - name: to Ansible Galaxy
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.head_ref == 'main')
-        uses: robertdebock/galaxy-action@1.0.3
+        uses: robertdebock/galaxy-action@1.1.1
         with:
           galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ Role Variables
 
 These variables are defined in [defaults/main.yml](./defaults/main.yml):
 
+    openssh_use_dotconfig_when_feasible: false
+
     openssh_configuration: {}
 
     openssh_configuration_match_blocks: {}
 
+Since OpenSSH v8.2 it is possible to use `Include` statement to load configuration from an [explicit directory](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=631189) (by default from `/etc/ssh/sshd_config.d`). The `openssh_add_dotconfig_when_feasible` enforces this pattern, when enabled.
 
 Dependencies
 ------------
@@ -37,7 +40,7 @@ Example Playbook
         - role: ansible-role-openssh
           vars:
             openssh_configuration:
-              #Include: /etc/ssh/sshd_config.d/*.conf
+              Include: /etc/ssh/sshd_config.d/*.conf
               ## Configuration
               Port: 22
               ListenAddress:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+openssh_use_dotconfig_when_feasible: false
+
 openssh_configuration: {}
 
 openssh_configuration_match_blocks: {}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@
 
 galaxy_info:
   role_name: openssh
+  namespace: provizanta
   author: Tibor Csóka
   description: |
     "Establish the openssh server configuration."

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -19,6 +19,8 @@ platforms:
 provisioner:
   log: true
   name: ansible
+#  options:
+#    D: true
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-playbook.yml}
     prepare: ${MOLECULE_PREPARE:-prepare.yml}

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -5,8 +5,8 @@
   roles:
     - role: ansible-role-openssh
       vars:
+        openssh_use_dotconfig_when_feasible: true
         openssh_configuration:
-          #Include: /etc/ssh/sshd_config.d/*.conf
           ## Configuration
           Port: 22
           ListenAddress:
@@ -16,9 +16,8 @@
             - LANG
             - LANGUAGE
             - LC_*
-          PrintMotd: no
-          Subsystem: sftp  /usr/lib/openssh/sftp-server
-          UsePAM: yes
+          PrintMotd: "no"
+          UsePAM: "yes"
           ## Ciphers
           Ciphers: aes128-ctr,aes192-ctr,aes256-ctr
           HostKeyAlgorithms: ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss
@@ -26,14 +25,14 @@
           MACs: hmac-sha2-256,hmac-sha2-512,hmac-sha1
           ## Security
           # Protocol: 2
-          PasswordAuthentication: no
-          PermitRootLogin: no
-          PermitEmptyPasswords: no
-          AllowTcpForwarding: no
-          AllowStreamLocalForwarding: no
-          GatewayPorts: no
-          PermitTunnel: no
-          ChallengeResponseAuthentication: no
+          PasswordAuthentication: "no"
+          PermitRootLogin: "no"
+          PermitEmptyPasswords: "no"
+          AllowTcpForwarding: "no"
+          AllowStreamLocalForwarding: "no"
+          GatewayPorts: "no"
+          PermitTunnel: "no"
+          ChallengeResponseAuthentication: "no"
           ClientAliveInterval: 180
           MaxAuthTries: 5
-          X11Forwarding: no
+          X11Forwarding: "no"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,11 +25,62 @@
     state: directory
     mode: "u=rwx,go=rx"
 
+- name: generate host keys
+  become: true
+  command:
+    cmd: "ssh-keygen -A"
+  changed_when: false
+
+- name: check installed version
+  shell: "ssh -V 2>&1"
+  register: _openssh_version_output
+  changed_when: false
+  failed_when: false
+
+- name: extract version
+  when: not _openssh_version_output.failed
+  set_fact:
+    _openssh_version: "{{ _openssh_version_output.stdout.split(' ') | first | regex_search('[0-9.]+') }}"
+  tags: always
+
+- name: facts | use config dirs
+  set_fact:
+    _openssh_can_use_config_dirs: "{{
+      openssh_use_dotconfig_when_feasible and
+      not _openssh_version_output.failed and
+      _openssh_version is defined and
+      _openssh_version is version('8.2', '>=') }}"
+  tags: always
+
+- name: establish configuration file directory
+  become: true
+  when:
+    - _openssh_can_use_config_dirs
+  loop: "{%
+       if 'Include' not in openssh_configuration %}{{ [openssh_configuration_file_d] }}{%
+       elif openssh_configuration['Include'].__class__.__name__ == 'list' %}{{
+         openssh_configuration['Include'] | map('dirname') | list }}{%
+       else %}{{ [openssh_configuration['Include'] | dirname] }}{% endif %}"
+  file:
+    path: "{{ item }}"
+    mode: "u=rwx,go=rx"
+    owner: root
+    group: root
+    state: directory
+
+- name: set configuration file path
+  set_fact:
+    _openssh_config_file_path: "{{ (_openssh_can_use_config_dirs and 'Include' not in openssh_configuration)
+      | ternary(openssh_configuration_file_d + '00-base.conf',
+                openssh_configuration_file) }}"
+  tags: always
+
 - name: configure openssh
-  when: openssh_configuration != {}
+  when:
+    - openssh_configuration != {}
   become: true
   template:
-    dest: "{{ openssh_configuration_file }}"
+    dest: "{{ _openssh_config_file_path }}"
     src: "sshd_config.j2"
     mode: "u=rw,go=r"
     owner: root
@@ -39,11 +90,12 @@
     - restart openssh
 
 - name: configure match blocks
-  when: openssh_configuration == {}
+  when:
+    - openssh_configuration == {}
   become: true
   loop: "{{ openssh_configuration_match_blocks | dict2items }}"
   blockinfile:
-    path: "{{ openssh_configuration_file }}"
+    path: "{{ _openssh_config_file_path }}"
     validate: sshd -f %s -t
     block: |
       Match {{ item.key }}
@@ -55,6 +107,7 @@
 
 - name: start and enable the service
   become: true
+  when: not ansible_check_mode
   service:
     name: "{{ openssh_service }}"
     state: started

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,8 @@ openssh_run_directory: /run/sshd
 
 openssh_configuration_file: /etc/ssh/sshd_config
 
+openssh_configuration_file_d: /etc/ssh/sshd_config.d/
+
 openssh_service: sshd
 
 openssh_default_port: 22


### PR DESCRIPTION
Ensure that best practices for OpenSSH v8.2+ are kept when configuring the service.

This solves the possible improvements identified in #1 in an API transparent way.